### PR TITLE
Fix CloudFormation YAML syntax error in eu-central-1 mapping

### DIFF
--- a/cfn/gpu-stack.yml
+++ b/cfn/gpu-stack.yml
@@ -36,7 +36,7 @@ Mappings:
     us-east-1:  {AMI: ami-0f5ee92e2d63afc18}
     us-east-2:  {AMI: ami-008b6a210f661cd08}
     us-west-2:  {AMI: ami-011ee32b3ca60ba85}
-    eu-central-1:{AMI: ami-053dfa9af5c5893b8}
+    eu-central-1: {AMI: ami-053dfa9af5c5893b8}
     eu-west-1:  {AMI: ami-0bb3facb3c7e1b45e}
 
 #####################


### PR DESCRIPTION
- Add missing space after colon in eu-central-1 region mapping
- Fixes ValidationError: 'Every Mappings member eu-central-1:{AMI must be a map'
- Resolves GitHub Actions deployment failure